### PR TITLE
feat: enhance TokenSelector component with disabled state and improve…

### DIFF
--- a/src/utils/validate-input/input-swap.ts
+++ b/src/utils/validate-input/input-swap.ts
@@ -1,17 +1,13 @@
 /**
- * Formata o valor do input de swap, permitindo apenas números e vírgula como separador decimal.
- * Substitui automaticamente pontos por vírgulas e garante que apenas uma vírgula seja permitida.
- * 
+ * Formata o valor do input de swap, permitindo apenas números, vírgula ou ponto como separadores decimais.
+ * Converte automaticamente vírgula para ponto ao final da edição.
+ *
  * @param value - O valor do input fornecido pelo usuário.
  * @returns O valor formatado.
  */
 export const formatInputValue = (value: string): string => {
-  // Remove caracteres inválidos e substitui ponto por vírgula
-  const sanitized = value.replace(/[^0-9.,]/g, ""); // Permite números, pontos e vírgulas
-  const normalized = sanitized.replace(".", ","); // Substitui ponto por vírgula
-  const parts = normalized.split(",");
-  // Garante que apenas uma vírgula esteja presente
-  return parts.length > 2
-    ? parts[0] + "," + parts.slice(1).join("")
-    : normalized;
+  // Permite números, vírgula e ponto enquanto o usuário digita
+  const sanitized = value.replace(/[^0-9.,]/g, "");
+  // Converte vírgula para ponto apenas ao finalizar
+  return sanitized.replace(",", ".");
 };


### PR DESCRIPTION
This pull request includes several updates to the `src/pages/buy.tsx` and `src/utils/validate-input/input-swap.ts` files to improve the functionality and user experience of the token selection and input value formatting. The most important changes include adding a `disabled` property to the `TokenSelector` component, preventing the selection of the same token in both fields, and updating the input value formatting.

### Token Selection Improvements:
* [`src/pages/buy.tsx`](diffhunk://#diff-4a7276a595ec0ec129a7e6d74737c27ae254186de6fa4c2ed2967098f32e38b6L33-L48): Added a `disabled` property to the `TokenSelector` component to disable the selection of the same token in both fields. [[1]](diffhunk://#diff-4a7276a595ec0ec129a7e6d74737c27ae254186de6fa4c2ed2967098f32e38b6L33-L48) [[2]](diffhunk://#diff-4a7276a595ec0ec129a7e6d74737c27ae254186de6fa4c2ed2967098f32e38b6R196-R200)
* [`src/pages/buy.tsx`](diffhunk://#diff-4a7276a595ec0ec129a7e6d74737c27ae254186de6fa4c2ed2967098f32e38b6R154-R156): Updated the `handleTokenSelect` function to prevent selecting the same token in both fields.

### Input Value Formatting:
* [`src/pages/buy.tsx`](diffhunk://#diff-4a7276a595ec0ec129a7e6d74737c27ae254186de6fa4c2ed2967098f32e38b6L163-R172): Modified the calculation of `valueTwo` to format the result with more precision and replace the decimal point with a comma.
* [`src/pages/buy.tsx`](diffhunk://#diff-4a7276a595ec0ec129a7e6d74737c27ae254186de6fa4c2ed2967098f32e38b6L203-R221): Updated the `onChange` handler for `valueOne` to format the input value before setting it.
* [`src/utils/validate-input/input-swap.ts`](diffhunk://#diff-1ab68c12afcf6b8de51fe62681d86813271bda02b62061baf3a3c44467308b2aL2-R12): Changed the `formatInputValue` function to allow both comma and point as decimal separators during input and convert comma to point at the end.… input formatting