### PR TITLE
fix: update token price API endpoint and add logging for fetched prices

### DIFF
--- a/src/api/abi/token-price.ts
+++ b/src/api/abi/token-price.ts
@@ -1,5 +1,3 @@
-const API_PRICE = import.meta.env.VITE_ORACLE_API_ENDPOINT as string;
-
 type PriceCache = {
   [key: string]: { usdPrice: string; timestamp: number };
 };

--- a/src/api/abi/token-price.ts
+++ b/src/api/abi/token-price.ts
@@ -29,8 +29,12 @@ export const useTokenPrices = () => {
     }
 
     try {
-      const response = await fetch(API_PRICE);
+      const response = await fetch(
+        "https://token-price-oracle.vercel.app/api/token-price?all=true"
+      );
       const data = await response.json();
+      console.log("Preços atualizados:", data);
+
 
       // Atualiza o cache com os dados retornados
       // Aqui assumimos que "data" tem formato conforme o exemplo:


### PR DESCRIPTION
This pull request includes a small change to the `src/api/abi/token-price.ts` file. The change updates the API endpoint used to fetch token prices and adds a console log to display the fetched data.

Changes in `export const useTokenPrices = () => {`:

* Updated the API endpoint to `https://token-price-oracle.vercel.app/api/token-price?all=true`.
* Added a console log to display the fetched token prices data.